### PR TITLE
relax matching rules for gems to support versioned dependencies

### DIFF
--- a/lib/technologist/frameworks.yml
+++ b/lib/technologist/frameworks.yml
@@ -1,11 +1,11 @@
 Locomotive:
   rules:
-    - Gemfile: ^gem 'locomotivecms_wagon'
+    - Gemfile: ^\s*gem 'locomotivecms_wagon'
   primary: Rails
 
 Rails:
   rules:
-    - Gemfile: ^gem 'rails'
+    - Gemfile: ^\s*gem 'rails'
 
 Magnolia:
   rules:
@@ -14,13 +14,13 @@ Magnolia:
 Sinatra:
   rules:
     - config.ru: run Sinatra::Application
-    - Gemfile: ^gem 'sinatra'
+    - Gemfile: ^\s*gem 'sinatra'
 
 Dashing:
   rules:
-    - Gemfile: ^gem 'dashing'
+    - Gemfile: ^\s*gem 'dashing'
   primary: Sinatra
 
 Middleman:
   rules:
-    - Gemfile: ^gem 'middleman'
+    - Gemfile: ^\s*gem 'middleman'

--- a/lib/technologist/frameworks.yml
+++ b/lib/technologist/frameworks.yml
@@ -1,11 +1,11 @@
 Locomotive:
   rules:
-    - Gemfile: ^gem 'locomotivecms_wagon'$
+    - Gemfile: ^gem 'locomotivecms_wagon'
   primary: Rails
 
 Rails:
   rules:
-    - Gemfile: ^gem 'rails'$
+    - Gemfile: ^gem 'rails'
 
 Magnolia:
   rules:
@@ -14,13 +14,13 @@ Magnolia:
 Sinatra:
   rules:
     - config.ru: run Sinatra::Application
-    - Gemfile: ^gem 'sinatra'$
+    - Gemfile: ^gem 'sinatra'
 
 Dashing:
   rules:
-    - Gemfile: ^gem 'dashing'$
+    - Gemfile: ^gem 'dashing'
   primary: Sinatra
 
 Middleman:
   rules:
-    - Gemfile: ^gem 'middleman'$
+    - Gemfile: ^gem 'middleman'

--- a/spec/frameworks_rules_spec.rb
+++ b/spec/frameworks_rules_spec.rb
@@ -26,7 +26,7 @@ describe 'Frameworks rules' do
       expect(repository.primary_frameworks).to eq ['Rails']
     end
 
-    it 'does not returns Rails when commented out' do
+    it 'does not return Rails when commented out' do
       repository = repository('Gemfile', "bogus\n# gem 'rails'\nbogus")
       expect(repository.primary_frameworks).to_not eq ['Rails']
     end
@@ -52,6 +52,21 @@ describe 'Frameworks rules' do
       expect(repository.primary_frameworks).to eq ['Sinatra']
       expect(repository.secondary_frameworks).to eq []
     end
+
+    it 'returns Sinatra when specified with version' do
+      repository = repository('Gemfile', "bogus\ngem 'sinatra', '~> 4.3'\nbogus")
+      expect(repository.primary_frameworks).to eq ['Sinatra']
+    end
+
+    it 'returns Sinatra when indented' do
+      repository = repository('Gemfile', "bogus\n  gem 'sinatra'\nbogus")
+      expect(repository.primary_frameworks).to eq ['Sinatra']
+    end
+
+    it 'does not return Sinatra when commented out' do
+      repository = repository('Gemfile', "bogus\n# gem 'sinatra'\nbogus")
+      expect(repository.primary_frameworks).to_not eq ['Sinatra']
+    end
   end
 
   describe 'Dashing' do
@@ -60,6 +75,21 @@ describe 'Frameworks rules' do
       expect(repository.primary_frameworks).to eq ['Sinatra']
       expect(repository.secondary_frameworks).to eq ['Dashing']
     end
+
+    it 'returns Sinatra when specified with version' do
+      repository = repository('Gemfile', "bogus\ngem 'dashing', '~> 4.3'\nbogus")
+      expect(repository.primary_frameworks).to eq ['Sinatra']
+    end
+
+    it 'returns Sinatra when indented' do
+      repository = repository('Gemfile', "bogus\n  gem 'dashing'\nbogus")
+      expect(repository.primary_frameworks).to eq ['Sinatra']
+    end
+
+    it 'does not return Sinatra when commented out' do
+      repository = repository('Gemfile', "bogus\n# gem 'dashing'\nbogus")
+      expect(repository.primary_frameworks).to_not eq ['Sinatra']
+    end
   end
 
   describe 'Middleman' do
@@ -67,6 +97,21 @@ describe 'Frameworks rules' do
       repository = repository('Gemfile', "bogus\ngem 'middleman'\nbogus")
       expect(repository.primary_frameworks).to eq ['Middleman']
       expect(repository.secondary_frameworks).to eq []
+    end
+
+    it 'returns Middleman when specified with version' do
+      repository = repository('Gemfile', "bogus\ngem 'middleman', '~> 4.3'\nbogus")
+      expect(repository.primary_frameworks).to eq ['Middleman']
+    end
+
+    it 'returns Middleman when indented' do
+      repository = repository('Gemfile', "bogus\n  gem 'middleman'\nbogus")
+      expect(repository.primary_frameworks).to eq ['Middleman']
+    end
+
+    it 'does not return Middleman when commented out' do
+      repository = repository('Gemfile', "bogus\n# gem 'middleman'\nbogus")
+      expect(repository.primary_frameworks).to_not eq ['Middleman']
     end
   end
 

--- a/spec/frameworks_rules_spec.rb
+++ b/spec/frameworks_rules_spec.rb
@@ -14,6 +14,12 @@ describe 'Frameworks rules' do
       expect(repository.secondary_frameworks).to eq []
     end
 
+    it 'returns Rails when specified with version' do
+      repository = repository('Gemfile', "bogus\ngem 'rails', '~> 4.3'\nbogus")
+      expect(repository.primary_frameworks).to eq ['Rails']
+      expect(repository.secondary_frameworks).to eq []
+    end
+
     it 'returns Magnolia' do
       repository = repository('pom.xml', "bogus\n    <magnoliaVersion>    \nbogus")
       expect(repository.primary_frameworks).to eq ['Magnolia']

--- a/spec/frameworks_rules_spec.rb
+++ b/spec/frameworks_rules_spec.rb
@@ -17,7 +17,16 @@ describe 'Frameworks rules' do
     it 'returns Rails when specified with version' do
       repository = repository('Gemfile', "bogus\ngem 'rails', '~> 4.3'\nbogus")
       expect(repository.primary_frameworks).to eq ['Rails']
-      expect(repository.secondary_frameworks).to eq []
+    end
+
+    it 'returns Rails when indented' do
+      repository = repository('Gemfile', "bogus\n  gem 'rails'\nbogus")
+      expect(repository.primary_frameworks).to eq ['Rails']
+    end
+
+    it 'does not returns Rails when commented out' do
+      repository = repository('Gemfile', "bogus\n# gem 'rails'\nbogus")
+      expect(repository.primary_frameworks).to_not eq ['Rails']
     end
 
     it 'returns Magnolia' do

--- a/spec/frameworks_rules_spec.rb
+++ b/spec/frameworks_rules_spec.rb
@@ -7,7 +7,9 @@ describe 'Frameworks rules' do
       expect(repository.primary_frameworks).to eq ['Rails']
       expect(repository.secondary_frameworks).to eq ['Locomotive']
     end
+  end
 
+  describe 'Rails' do
     it 'returns Rails' do
       repository = repository('Gemfile', "bogus\ngem 'rails'\nbogus")
       expect(repository.primary_frameworks).to eq ['Rails']
@@ -28,13 +30,17 @@ describe 'Frameworks rules' do
       repository = repository('Gemfile', "bogus\n# gem 'rails'\nbogus")
       expect(repository.primary_frameworks).to_not eq ['Rails']
     end
+  end
 
+  describe 'Magnolia' do
     it 'returns Magnolia' do
       repository = repository('pom.xml', "bogus\n    <magnoliaVersion>    \nbogus")
       expect(repository.primary_frameworks).to eq ['Magnolia']
       expect(repository.secondary_frameworks).to eq []
     end
+  end
 
+  describe 'Sinatra' do
     it 'returns Sinatra (1)' do
       repository = repository('config.ru', "bogus\nrun Sinatra::Application\nbogus")
       expect(repository.primary_frameworks).to eq ['Sinatra']
@@ -46,13 +52,17 @@ describe 'Frameworks rules' do
       expect(repository.primary_frameworks).to eq ['Sinatra']
       expect(repository.secondary_frameworks).to eq []
     end
+  end
 
+  describe 'Dashing' do
     it 'returns Dashing' do
       repository = repository('Gemfile', "bogus\ngem 'dashing'\nbogus")
       expect(repository.primary_frameworks).to eq ['Sinatra']
       expect(repository.secondary_frameworks).to eq ['Dashing']
     end
+  end
 
+  describe 'Middleman' do
     it 'returns Middleman' do
       repository = repository('Gemfile', "bogus\ngem 'middleman'\nbogus")
       expect(repository.primary_frameworks).to eq ['Middleman']

--- a/spec/frameworks_rules_spec.rb
+++ b/spec/frameworks_rules_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'Frameworks rules' do
   describe 'Locomotive' do
-    it 'returns Dashing' do
+    it 'returns Locomotive' do
       repository = repository('Gemfile', "bogus\ngem 'locomotivecms_wagon'\nbogus")
       expect(repository.primary_frameworks).to eq ['Rails']
       expect(repository.secondary_frameworks).to eq ['Locomotive']


### PR DESCRIPTION
In the Gemfile one may specify a version (or other arguments) when
declaring dependencies. Those dependencies were not detected with the
rule set.

This patch relaxes the RegEx used to detect gem dependencies by dropping
the `$`.

NOTE: only the test for one framework (Rails) has been adapted.