### PR TITLE
relax dependency version for bundler

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,7 @@
 require "bundler/gem_tasks"
 
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/technologist.gemspec
+++ b/technologist.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "rugged", "~> 0.23.3"
 
-  spec.add_development_dependency "bundler", "~> 1.8"
+  spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.3.0"
 end


### PR DESCRIPTION
Both huerlisi and travis were bitten by a quite restrictive version
dependency on `bundler`. But we actually do not need any modern
features.

This patch relaxes the version from `~> 1.8` to `~> 1.7` for bundler.