### PR TITLE
enable travis-ci caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: ruby
+cache: bundler
 rvm:
   - 2.0.0


### PR DESCRIPTION
Travis supports caching of gems. This will speedup the test runs.

This patch add the `cache: bundler` to the travis config.