### PR TITLE
Simplify yaml rules configuration

### DIFF
--- a/lib/technologist/framework_detector.rb
+++ b/lib/technologist/framework_detector.rb
@@ -33,7 +33,7 @@ module Technologist
         begin
           yaml_parser.rules.map do |technology, definition|
             definition['rules'].map do |rule|
-              if rule.matches?(technology, repository)
+              if rule.matches?(repository)
                 technology
               end
             end

--- a/lib/technologist/framework_detector.rb
+++ b/lib/technologist/framework_detector.rb
@@ -1,40 +1,37 @@
-require 'yaml'
+require 'technologist/yaml_parser'
 
 module Technologist
   class FrameworkDetector
     FRAMEWORK_RULES = File.expand_path('../frameworks.yml',  __FILE__)
 
+    attr_reader :repository, :yaml_parser
+
     def initialize(repository)
       @repository = repository
+      @yaml_parser = YamlParser.new(FRAMEWORK_RULES)
     end
 
     def primary_frameworks
       matched_frameworks.map do |technology|
         # it's either the primary value defined in the yaml
         # or the technology itself
-        rules[technology]['primary'] || technology
+        yaml_parser.rules[technology]['primary'] || technology
       end.uniq
     end
 
     def secondary_frameworks
       matched_frameworks.map do |technology|
         # it's a secondary if a primary is defined in the yaml
-        rules[technology]['primary'] && technology
+        yaml_parser.rules[technology]['primary'] && technology
       end.compact
     end
 
     private
 
-    attr_reader :repository
-
-    def rules
-      @rules ||= YAML.load_file(FRAMEWORK_RULES)
-    end
-
     def matched_frameworks
       @frameworks ||=
         begin
-          rules.map do |technology, definition|
+          yaml_parser.rules.map do |technology, definition|
             definition['rules'].map do |rule|
               if rule.matches?(technology, repository)
                 technology

--- a/lib/technologist/frameworks.yml
+++ b/lib/technologist/frameworks.yml
@@ -1,103 +1,120 @@
 Rails:
   rules:
-    - !ruby/object:GemRule {}
-    - !ruby/object:GemRule { gem_name: 'jrails' }
-    - !ruby/object:FileContentRule { file_name: 'boot.rb', file_content_pattern: 'Rails.boot!' }
+    - Gem
+    - Gem:
+      gem_name: 'jrails'
+    - FileContent:
+      file_name: 'boot.rb'
+      file_content_pattern: 'Rails.boot!'
 
 Locomotive:
   rules:
-    - !ruby/object:GemRule { gem_name: 'locomotivecms_wagon' }
+    - Gem:
+      gem_name: 'locomotivecms_wagon'
   primary: Rails
 
 Magnolia:
   rules:
-    - !ruby/object:FileContentRule { file_name: 'pom.xml', file_content_pattern: '<magnoliaVersion>' }
+    - FileContent:
+      file_name: 'pom.xml'
+      file_content_pattern: '<magnoliaVersion>'
 
 Sinatra:
   rules:
-    - !ruby/object:FileContentRule { file_name: 'config.ru', file_content_pattern: 'run Sinatra::Application' }
-    - !ruby/object:GemRule {}
+    - FileContent:
+      file_name: 'config.ru'
+      file_content_pattern: 'run Sinatra::Application'
+    - Gem
 
 Dashing:
   rules:
-    - !ruby/object:GemRule {}
+    - Gem
   primary: Sinatra
 
 Middleman:
   rules:
-    - !ruby/object:GemRule {}
+    - Gem
 
 Meteor:
   rules:
-    - !ruby/object:DirectoryPresenceRule { directory_name: '.meteor' }
+    - DirectoryPresence:
+      directory_name: '.meteor'
 
 Spree:
   rules:
-    - !ruby/object:GemRule {}
-    - !ruby/object:FileContentRule { file_name: 'boot.rb', file_content_pattern: 'Spree.boot!' }
+    - Gem
+    - FileContent:
+      file_name: 'boot.rb'
+      file_content_pattern: 'Spree.boot!'
   primary: Rails
 
 Wordpress:
   rules:
-    - !ruby/object:FilePresenceRule { file_name: 'wp-settings.php' }
+    - FilePresence:
+      file_name: 'wp-settings.php'
 
 Volt:
   rules:
-    - !ruby/object:GemRule {}
+    - Gem
 
 Ionic:
   rules:
-    - !ruby/object:FilePresenceRule { file_name: 'ionic.project' }
+    - FilePresence:
+      file_name: 'ionic.project'
 
 Node:
   rules:
-    - !ruby/object:FileContentRule
+    - FileContent:
       file_name: 'package.json'
       file_content_pattern: '^\s*"node":'
 
 Hoodie:
   rules:
-    - !ruby/object:FileContentRule
+    - FileContent:
       file_name: 'package.json'
       file_content_pattern: '"hoodie":\s*{'
   primary: Node
 
 PrestaShop:
   rules:
-    - !ruby/object:FileContentRule { file_name: 'init.php', file_content_pattern: 'PrestaShop' }
+    - FileContent:
+      file_name: 'init.php'
+      file_content_pattern: 'PrestaShop'
 
 Cordova:
   rules:
-    - !ruby/object:FileContentRule
+    - FileContent:
       file_name: 'config.xml'
       file_content_pattern: '\bxmlns:cdv="http://cordova.apache.org/ns/.+"'
 
 iOS:
   rules:
-    - !ruby/object:FileContentRule
+    - FileContent:
       file_name: 'project.pbxproj'
       file_content_pattern: '\n\s*SDKROOT = iphoneos;\n'
 
 Refinery CMS:
   rules:
-    - !ruby/object:GemRule { gem_name: 'refinerycms' }
+    - Gem:
+      gem_name: 'refinerycms'
   primary: Rails
 
 Rack:
   rules:
-    - !ruby/object:GemRule { gem_name: 'rack' }
-    - !ruby/object:FileContentRule
+    - Gem:
+      gem_name: 'rack'
+    - FileContent:
       file_name: 'config.ru'
       file_content_pattern: 'run Proc\.new { \|env\|'
 
 Magento:
   rules:
-    - !ruby/object:FileContentRule
+    - FileContent:
       file_name: 'composer.json'
       file_content_pattern: '^\s*"magento":\s*{\s*$'
 
 Vaadin:
   rules:
-    - !ruby/object:FileContentRule
+    - FileContent:
       file_name: 'pom.xml'
       file_content_pattern: '<version>\${vaadin.base.version}</version>'

--- a/lib/technologist/rules/directory_presence_rule.rb
+++ b/lib/technologist/rules/directory_presence_rule.rb
@@ -3,7 +3,7 @@ require 'technologist/rules/rule'
 class DirectoryPresenceRule < Rule
   attr_accessor :directory_name
 
-  def matches?(framework_name, repository)
+  def matches?(repository)
     repository.directory_exists?(directory_name)
   end
 end

--- a/lib/technologist/rules/file_content_rule.rb
+++ b/lib/technologist/rules/file_content_rule.rb
@@ -3,7 +3,7 @@ require 'technologist/rules/rule'
 class FileContentRule < Rule
   attr_accessor :file_name, :file_content_pattern
 
-  def matches?(framework_name, repository)
+  def matches?(repository)
     !!repository.file_with_content_exists?(file_name) do |content|
       content =~ /#{file_content_pattern}/
     end

--- a/lib/technologist/rules/file_presence_rule.rb
+++ b/lib/technologist/rules/file_presence_rule.rb
@@ -3,7 +3,7 @@ require 'technologist/rules/rule'
 class FilePresenceRule < Rule
   attr_accessor :file_name
 
-  def matches?(framework_name, repository)
+  def matches?(repository)
     repository.file_exists?(file_name)
   end
 end

--- a/lib/technologist/rules/gem_rule.rb
+++ b/lib/technologist/rules/gem_rule.rb
@@ -3,9 +3,14 @@ require 'technologist/rules/file_content_rule'
 class GemRule < FileContentRule
   attr_accessor :gem_name
 
-  def matches?(framework_name, repository)
+  def initialize(framework, attributes = {})
+    super
+
     self.file_name = 'Gemfile'
-    self.gem_name ||= framework_name.downcase
+    self.gem_name ||= framework.downcase
+  end
+
+  def matches?(repository)
     self.file_content_pattern = /^\s*gem ["']#{gem_name}["']/
 
     super

--- a/lib/technologist/rules/rule.rb
+++ b/lib/technologist/rules/rule.rb
@@ -1,9 +1,13 @@
 class Rule
-  def initialize(attributes = {})
+  attr_accessor :framework
+
+  def initialize(framework, attributes = {})
+    self.framework = framework
+
     attributes.each { |name, value| self.send(:"#{name}=", value) }
   end
 
-  def matches?(framework_name, repository)
+  def matches?(repository)
     false
   end
 end

--- a/lib/technologist/yaml_parser.rb
+++ b/lib/technologist/yaml_parser.rb
@@ -1,0 +1,67 @@
+require 'yaml'
+
+module Technologist
+  class YamlParser
+    attr_reader :file_name
+
+    def initialize(file_name)
+      @file_name = file_name
+    end
+
+    def rules
+      @rules ||=
+        begin
+          parsed_rules = from_file.map do |technology, definition|
+            # Create a class instance for each rule entry
+            definition['rules'].map! do |rule|
+              class_name, attributes = send("parse_rule_of_type_#{rule.class.name.downcase}", rule)
+
+              Rule.const_get("#{class_name}Rule").new(attributes)
+            end
+
+            [technology, definition]
+          end
+
+          Hash[parsed_rules]
+        end
+    end
+
+    private
+
+    def from_file
+      YAML.load_file(file_name)
+    end
+
+    # Parses a yaml rule where the rule entry is a string,
+    # meaning that only the rule class name is given.
+    # Sample yaml structure:
+    #   ```
+    #     Rails:
+    #       rules:
+    #         - Gem
+    #   ```
+    def parse_rule_of_type_hash(rule)
+      class_name = rule.keys.first
+      rule.delete(class_name)
+      attributes = rule
+
+      [class_name, attributes]
+    end
+
+    # Parses a yaml rule where the rule entry is a hash,
+    # meaning that the rule class also has attributes to be assigned.
+    # Sample yaml structure:
+    #   ```
+    #     Rails:
+    #       rules:
+    #         - Gem:
+    #           gem_name: 'jrails'
+    #   ```
+    def parse_rule_of_type_string(rule)
+      class_name = rule
+      attributes = {}
+
+      [class_name, attributes]
+    end
+  end
+end

--- a/lib/technologist/yaml_parser.rb
+++ b/lib/technologist/yaml_parser.rb
@@ -16,7 +16,7 @@ module Technologist
             definition['rules'].map! do |rule|
               class_name, attributes = send("parse_rule_of_type_#{rule.class.name.downcase}", rule)
 
-              Rule.const_get("#{class_name}Rule").new(attributes)
+              Rule.const_get("#{class_name}Rule").new(technology, attributes)
             end
 
             [technology, definition]

--- a/lib/technologist/yaml_parser.rb
+++ b/lib/technologist/yaml_parser.rb
@@ -12,11 +12,8 @@ module Technologist
       @rules ||=
         begin
           parsed_rules = from_file.map do |technology, definition|
-            # Create a class instance for each rule entry
             definition['rules'].map! do |rule|
-              class_name, attributes = send("parse_rule_of_type_#{rule.class.name.downcase}", rule)
-
-              Rule.const_get("#{class_name}Rule").new(technology, attributes)
+              instancify(technology, rule)
             end
 
             [technology, definition]
@@ -30,6 +27,13 @@ module Technologist
 
     def from_file
       YAML.load_file(file_name)
+    end
+
+    # Create a class instance for a rule entry
+    def instancify(technology, rule)
+      class_name, attributes = send("parse_rule_of_type_#{rule.class.name.downcase}", rule)
+
+      Rule.const_get("#{class_name}Rule").new(technology, attributes)
     end
 
     # Parses a yaml rule where the rule entry is a string,

--- a/spec/rules/directory_presence_rule_spec.rb
+++ b/spec/rules/directory_presence_rule_spec.rb
@@ -2,22 +2,22 @@ require 'spec_helper'
 
 describe DirectoryPresenceRule do
   describe '#matches?' do
-    it 'returns true when the directy exists' do
-      rule = DirectoryPresenceRule.new(directory_name: 'dir1')
+    it 'returns true when the directory exists' do
+      rule = DirectoryPresenceRule.new('Framework1', directory_name: 'dir1')
 
       repository = double(:repository)
       allow(repository).to receive(:directory_exists?).with('dir1').and_return(true)
 
-      expect(rule.matches?('Framework1', repository)).to eq true
+      expect(rule.matches?(repository)).to eq true
     end
   end
 
-  it 'returns false when the directy does not exists' do
-    rule = DirectoryPresenceRule.new(directory_name: 'dir1')
+  it 'returns false when the directory does not exists' do
+    rule = DirectoryPresenceRule.new('Framework1', directory_name: 'dir1')
 
     repository = double(:repository)
     allow(repository).to receive(:directory_exists?).with('dir1').and_return(false)
 
-    expect(rule.matches?('Framework1', repository)).to eq false
+    expect(rule.matches?(repository)).to eq false
   end
 end

--- a/spec/rules/file_content_rule_spec.rb
+++ b/spec/rules/file_content_rule_spec.rb
@@ -3,30 +3,30 @@ require 'spec_helper'
 describe FileContentRule do
   describe '#matches?' do
     it 'returns true when the file contains the string' do
-      rule = FileContentRule.new(file_name: 'file1', file_content_pattern: 'content1')
+      rule = FileContentRule.new('Framework1', file_name: 'file1', file_content_pattern: 'content1')
 
       repository = double(:repository)
       allow(repository).to receive(:file_with_content_exists?).with('file1').and_yield('content1')
 
-      expect(rule.matches?('Framework1', repository)).to eq true
+      expect(rule.matches?(repository)).to eq true
     end
 
     it 'returns true when the file contains the pattern' do
-      rule = FileContentRule.new(file_name: 'file1', file_content_pattern: /content\d/)
+      rule = FileContentRule.new('Framework1', file_name: 'file1', file_content_pattern: /content\d/)
 
       repository = double(:repository)
       allow(repository).to receive(:file_with_content_exists?).with('file1').and_yield('content1')
 
-      expect(rule.matches?('Framework1', repository)).to eq true
+      expect(rule.matches?(repository)).to eq true
     end
 
     it 'returns false when the file does not contain the string' do
-      rule = FileContentRule.new(file_name: 'file1', file_content_pattern: 'content1')
+      rule = FileContentRule.new('Framework1', file_name: 'file1', file_content_pattern: 'content1')
 
       repository = double(:repository)
       allow(repository).to receive(:file_with_content_exists?).with('file1').and_yield('bogus')
 
-      expect(rule.matches?('Framework1', repository)).to eq false
+      expect(rule.matches?(repository)).to eq false
     end
   end
 end

--- a/spec/rules/file_presence_rule_spec.rb
+++ b/spec/rules/file_presence_rule_spec.rb
@@ -3,21 +3,21 @@ require 'spec_helper'
 describe FilePresenceRule do
   describe '#matches?' do
     it 'returns true when the file exists' do
-      rule = FilePresenceRule.new(file_name: 'file1')
+      rule = FilePresenceRule.new('Framework1', file_name: 'file1')
 
       repository = double(:repository)
       allow(repository).to receive(:file_exists?).with('file1').and_return(true)
 
-      expect(rule.matches?('Framework1', repository)).to eq true
+      expect(rule.matches?(repository)).to eq true
     end
   end
 
   it 'returns false when the file does not exists' do
-    rule = FilePresenceRule.new(file_name: 'file1')
+    rule = FilePresenceRule.new('Framework1', file_name: 'file1')
 
     repository = double(:repository)
     allow(repository).to receive(:file_exists?).with('file1').and_return(false)
 
-    expect(rule.matches?('Framework1', repository)).to eq false
+    expect(rule.matches?(repository)).to eq false
   end
 end

--- a/spec/rules/gem_rule_spec.rb
+++ b/spec/rules/gem_rule_spec.rb
@@ -3,83 +3,83 @@ require 'spec_helper'
 describe GemRule do
   describe '#matches?' do
     it 'returns true when the Gemfile contains the explicitely defined gem name' do
-      rule = GemRule.new(gem_name: 'next_generation_gem')
+      rule = GemRule.new('Framework1', gem_name: 'next_generation_gem')
 
       repository = double(:repository)
       allow(repository).to receive(:file_with_content_exists?).with('Gemfile')
         .and_yield("content\ngem 'next_generation_gem'\ncontent")
 
-      expect(rule.matches?('Framework1', repository)).to eq true
+      expect(rule.matches?(repository)).to eq true
     end
 
     it 'returns true when the Gemfile contains the inferred gem name' do
-      rule = GemRule.new
+      rule = GemRule.new('Framework1')
 
       repository = double(:repository)
       allow(repository).to receive(:file_with_content_exists?).with('Gemfile')
         .and_yield("content\ngem 'framework1'\ncontent")
 
-      expect(rule.matches?('Framework1', repository)).to eq true
+      expect(rule.matches?(repository)).to eq true
     end
 
     it 'returns true when the gem name is in double quotes' do
-      rule = GemRule.new(gem_name: 'next_generation_gem')
+      rule = GemRule.new('Framework1', gem_name: 'next_generation_gem')
 
       repository = double(:repository)
       allow(repository).to receive(:file_with_content_exists?).with('Gemfile')
         .and_yield("content\ngem \"next_generation_gem\"\ncontent")
 
-      expect(rule.matches?('Framework1', repository)).to eq true
+      expect(rule.matches?(repository)).to eq true
     end
 
     it 'returns true when the gem name is in single quotes' do
-      rule = GemRule.new(gem_name: 'next_generation_gem')
+      rule = GemRule.new('Framework1', gem_name: 'next_generation_gem')
 
       repository = double(:repository)
       allow(repository).to receive(:file_with_content_exists?).with('Gemfile')
         .and_yield("content\ngem 'next_generation_gem'\ncontent")
 
-      expect(rule.matches?('Framework1', repository)).to eq true
+      expect(rule.matches?(repository)).to eq true
     end
 
     it 'returns true when the gem is specified with a version' do
-      rule = GemRule.new(gem_name: 'next_generation_gem')
+      rule = GemRule.new('Framework1', gem_name: 'next_generation_gem')
 
       repository = double(:repository)
       allow(repository).to receive(:file_with_content_exists?).with('Gemfile')
         .and_yield("content\ngem 'next_generation_gem', '~> 4.3'\ncontent")
 
-      expect(rule.matches?('Framework1', repository)).to eq true
+      expect(rule.matches?(repository)).to eq true
     end
 
     it "returns true when the gem definition is indented" do
-      rule = GemRule.new(gem_name: 'next_generation_gem')
+      rule = GemRule.new('Framework1', gem_name: 'next_generation_gem')
 
       repository = double(:repository)
       allow(repository).to receive(:file_with_content_exists?).with('Gemfile')
         .and_yield("content\n  gem 'next_generation_gem'\ncontent")
 
-      expect(rule.matches?('Framework1', repository)).to eq true
+      expect(rule.matches?(repository)).to eq true
     end
 
     it "returns false when the gem is commented out" do
-      rule = GemRule.new(gem_name: 'next_generation_gem')
+      rule = GemRule.new('Framework1', gem_name: 'next_generation_gem')
 
       repository = double(:repository)
       allow(repository).to receive(:file_with_content_exists?).with('Gemfile')
         .and_yield("content\n# gem 'next_generation_gem'\ncontent")
 
-      expect(rule.matches?('Framework1', repository)).to eq false
+      expect(rule.matches?(repository)).to eq false
     end
 
     it 'returns false when the Gemfile does not contain the gem' do
-      rule = GemRule.new(gem_name: 'next_generation_gem')
+      rule = GemRule.new('Framework1', gem_name: 'next_generation_gem')
 
       repository = double(:repository)
       allow(repository).to receive(:file_with_content_exists?).with('Gemfile')
         .and_yield("content\ngem 'last_generation_gem'\ncontent")
 
-      expect(rule.matches?('Framework1', repository)).to eq false
+      expect(rule.matches?(repository)).to eq false
     end
   end
 end

--- a/spec/yaml_parser_spec.rb
+++ b/spec/yaml_parser_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Technologist::YamlParser do
       expect(rules['primary']).to eq 'Rack'
 
       expect(rules['rules'][0]).to be_an_instance_of GemRule
-      expect(rules['rules'][0].gem_name).to be_nil
+
+      expect(rules['rules'][0].gem_name).to eq 'rails'
 
       expect(rules['rules'][1]).to be_an_instance_of GemRule
       expect(rules['rules'][1].gem_name).to eq 'jrails'

--- a/spec/yaml_parser_spec.rb
+++ b/spec/yaml_parser_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe Technologist::YamlParser do
+  describe '#rules' do
+    it 'maps the config to rule classes' do
+      yaml_parser = Technologist::YamlParser.new(nil)
+      allow(yaml_parser).to receive(:from_file) {
+        YAML.load(%{
+          Rails:
+            rules:
+              - Gem
+              - Gem:
+                gem_name: 'jrails'
+              - FileContent:
+                file_name: 'boot.rb'
+                file_content_pattern: 'Rails.boot!'
+            primary: Rack
+        })
+      }
+
+      rules = yaml_parser.rules['Rails']
+
+      expect(rules['rules'].count).to eq 3
+
+      expect(rules['primary']).to eq 'Rack'
+
+      expect(rules['rules'][0]).to be_an_instance_of GemRule
+      expect(rules['rules'][0].gem_name).to be_nil
+
+      expect(rules['rules'][1]).to be_an_instance_of GemRule
+      expect(rules['rules'][1].gem_name).to eq 'jrails'
+
+      expect(rules['rules'][2]).to be_an_instance_of FileContentRule
+      expect(rules['rules'][2].file_name).to eq 'boot.rb'
+      expect(rules['rules'][2].file_content_pattern).to eq 'Rails.boot!'
+    end
+  end
+end


### PR DESCRIPTION
Remove the ruby code and replace it by using
a more config-like syntax, as e.g. used by
rubocop and overcommit.

/cc @huerlisi